### PR TITLE
Exit quickly when cmake or make fail

### DIFF
--- a/Keyboards/cmake.bash
+++ b/Keyboards/cmake.bash
@@ -82,7 +82,18 @@ done
 mkdir -p "${BuildPath}"
 cd "${BuildPath}"
 cmake -DCHIP="${Chip}" -DCOMPILER="${Compiler}" -DScanModule="${ScanModule}" -DMacroModule="${MacroModule}" -DOutputModule="${OutputModule}" -DDebugModule="${DebugModule}" -DBaseMap="${BaseMap}" -DDefaultMap="${DefaultMap}" -DPartialMaps="${PartialMapsExpanded}" "${CMakeListsPath}"
+return_code=$?
+if [ $return_code != 0 ] ; then
+  echo "Error in cmake. Exiting..."
+  exit $return_code
+fi
+
 make
+return_code=$?
+if [ $return_code != 0 ] ; then
+  echo "Error in make. Exiting..."
+  exit $return_code
+fi
 
 echo "Firmware has been compiled into: '${BuildPath}'"
 cd -


### PR DESCRIPTION
The compilation process itself doesn't take very long, but it's weird to let it continue trying to build when we've encountered an error worthy of changing cmake/make's return codes. This gives clear indication of a failed build as the last line of the script's output.

There are probably more elegant and bash-y ways of doing this and keeping to DRY; let me know if you'd rather I do a larger refactoring.