### PR TITLE
Stop requiring editing of example scripts

### DIFF
--- a/Scan/ISSILed/exampleAPI.bash
+++ b/Scan/ISSILed/exampleAPI.bash
@@ -3,9 +3,15 @@
 # Virtual Serial Port API Example
 # Jacob Alexander 2015
 
+if [ $# -eq 0 ]; then
+  echo "You must specify your virtual serialport. (/dev/ttyACM0 on linux, /dev/cu.usbmodemXXXX on OSX)"
+  echo "  ex: $0 /dev/ttyACM0"
+  exit 1
+fi
 # XXX Set this to match your virtual serialport
-# TODO Show examples for Mac OSX and Cygwin/Windows
-SERIALPORT=/dev/ttyACM0
+# TODO Show examples for Cygwin/Windows
+# For Mac OSX it will be something like /dev/cu.usbmodem1413 (number may differ)
+SERIALPORT=$1
 
 # NOTE: Make sure you don't write too quickly to the serial port, it can get overwhelmed by a modern computer
 #       Generally this just means commands will get ignored

--- a/Scan/STLcd/bitmap2Struct.py
+++ b/Scan/STLcd/bitmap2Struct.py
@@ -110,7 +110,10 @@ class STLcdGraphic:
 		return display
 
 
-filename = "ic_logo_lcd.bmp"
+filename = sys.argv[1]
+if filename is None:
+	print( "You must specify a bitmap filename. Try './bitmap2Struct.py ic_logo_lcd.bmp'" )
+	sys.exit( 1 )
 max_height = 32
 max_width = 128
 x_offset = 0

--- a/Scan/STLcd/exampleAPI.bash
+++ b/Scan/STLcd/exampleAPI.bash
@@ -3,9 +3,15 @@
 # Virtual Serial Port API Example
 # Jacob Alexander 2015
 
+if [ $# -eq 0 ]; then
+  echo "You must specify your virtual serialport. (/dev/ttyACM0 on linux, /dev/cu.usbmodemXXXX on OSX)"
+  echo "  ex: $0 /dev/ttyACM0"
+  exit 1
+fi
 # XXX Set this to match your virtual serialport
-# TODO Show examples for Mac OSX and Cygwin/Windows
-SERIALPORT=/dev/ttyACM0
+# TODO Show example for Cygwin/Windows
+# For Mac OSX it will be something like /dev/cu.usbmodem1413 (number may differ)
+SERIALPORT=$1
 
 # NOTE: Make sure you don't write too quickly to the serial port, it can get overwhelmed by a modern computer
 #       Generally this just means commands will get ignored


### PR DESCRIPTION
The example scripts include hardcoded values that
do not work for everyone. Instead of requiring the
files to be edited (and dirtying the git tree),
allow them to take command-line arguments.

Also adds better guidance for Mac OSX virtual
serial ports.