### PR TITLE
Ensure directories can only be made with printable characters

### DIFF
--- a/buildall.bash
+++ b/buildall.bash
@@ -31,7 +31,8 @@ main() {
 	# Create permutation directories
 	# Then run cmake, and run each build permutation
 	# Keeping track of how many builds failed/passed
-	for module in $scanModules; do
+	for mod in $scanModules; do
+		module=$(tr -dc "[:print:]" <<< "$mod")
 		# Create directory, but do not error if it exists already
 		mkdir -p build/$module
 		cd build/$module


### PR DESCRIPTION
In situations where `ls` colors directories incorrectly, the `$module`
variable contains unprintable characters. This causes directories to be
impossible to `cd` into normally, and is generally a pain.