### PR TITLE
Ignore BuildPath directories

### DIFF
--- a/Keyboards/.gitignore
+++ b/Keyboards/.gitignore
@@ -1,0 +1,5 @@
+# Ignore BuildPath directories
+/ICED-L/
+/IC60/
+/template/
+/WhiteFox/


### PR DESCRIPTION
Ignore all the default BuildPath directories created by the bash scripts via cmake.bash.

---

This is pretty minor, just wanted to clean up my git-status output.

I added this to `Keyboards/.gitignore`, you may prefer to add this to the `.gitignore` at the root of the project.

Also, it might be simpler to just make a `Keyboards/build` directory to contain all the output directories and ignore that instead.