### PR TITLE
Adding keyBlock capability to support Programmmer's Dvorak

### DIFF
--- a/Keyboards/infinity_programmers_dvorak.bash
+++ b/Keyboards/infinity_programmers_dvorak.bash
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# This script shows how to use a complex multi-file layout such as Programmer's Dvorak
+# Jacob Alexander 2016
+
+
+
+#################
+# Configuration #
+#################
+
+# Feel free to change the variables in this section to configure your keyboard
+
+BuildPath="IC60"
+
+## KLL Configuration ##
+
+# Generally shouldn't be changed, this will affect every layer
+BaseMap="scancode_map"
+
+# This is the default layer of the keyboard
+# NOTE: To combine kll files into a single layout, separate them by spaces
+# e.g.  DefaultMap="mylayout mylayoutmod"
+DefaultMap="programmers_dvorak_default stdFuncMap"
+
+# This is where you set the additional layers
+# NOTE: Indexing starts at 1
+# NOTE: Each new layer is another array entry
+# e.g.  PartialMaps[1]="layer1 layer1mod"
+#       PartialMaps[2]="layer2"
+#       PartialMaps[3]="layer3"
+PartialMaps[1]="programmers_dvorak_shift"
+
+
+
+##########################
+# Advanced Configuration #
+##########################
+
+# Don't change the variables in this section unless you know what you're doing
+# These are useful for completely custom keyboards
+# NOTE: Changing any of these variables will require a force build to compile correctly
+
+# Keyboard Module Configuration
+ScanModule="Infinity_60%"
+MacroModule="PartialMap"
+OutputModule="pjrcUSB"
+DebugModule="full"
+
+# Microcontroller
+Chip="mk20dx128vlf5"
+
+# Compiler Selection
+Compiler="gcc"
+
+
+
+########################
+# Bash Library Include #
+########################
+
+# Shouldn't need to touch this section
+
+# Check if the library can be found
+if [ ! -f cmake.bash ]; then
+	echo "ERROR: Cannot find 'cmake.bash'"
+	exit 1
+fi
+
+# Load the library
+source cmake.bash
+

--- a/Macro/PartialMap/capabilities.kll
+++ b/Macro/PartialMap/capabilities.kll
@@ -1,10 +1,10 @@
 Name = PartialMapCapabilities;
-Version = 0.3;
+Version = 0.4;
 Author = "HaaTa (Jacob Alexander) 2014-2016";
 KLL = 0.3d;
 
 # Modified Date
-Date = 2016-04-08;
+Date = 2016-08-06;
 
 
 # Capabilties available to the PartialMap module
@@ -24,4 +24,21 @@ stateWordSize = 8; # Default for now, increase to 16 or 32 for higher limits
 
 indexWordSize => IndexWordSize_define;
 indexWordSize = 16; # Default for now, increase to 32 for higher limits (8 for less resource usage)
+
+# Block Key Capability
+# Add this capability as a combo to any key you want to explicitly block another
+# For example:
+# To turn Shift+1 into q
+# U"Shift" + U"1" : U"Q" + blockKey( 0xE1 ) + blockKey( 0x1E );
+#
+# 0xE1 - Left Shift (0xE5 is Right Shift)
+# 0x1E - 1
+#
+# NOTE: KLL is limited to using numbers for key blocking instead of the symbolic names
+#       A future version of KLL will address this
+blockKey => Macro_blockUSBKey_capability( usbCode : 1 );
+
+# This defines the maximum number of keys that can be blocked in a single processing loop
+maxBlockCount => Macro_maxBlockCount_define;
+maxBlockCount = 4;
 


### PR DESCRIPTION
- Useful for partial redefinitions of keys
  Such as redefining Shift, which, as per the USB spec is handled by the OS
  This means we have to careful select which USB Codes to send to the OS to simulate Shift not being pressed (while it is)
- KLL capabilities only work with numerical arguments (KLL 0.3d)
- Each key must be explicitly block for each combination (e.g. LShift and RShift are handled separately)

- Adding example configuration for the Infinity 60%
- Requires kll.git 1a078b2b940709bc3c429c952d2f0d842927394f or higher


Alistair, I haven't tested this code at all. It does compile, and functionally is quite simple.
You'll need the following commits from kll.git
https://github.com/kiibohd/kll/commit/0e898827ca7fb6dd0f6227085cf896817a2d0620
https://github.com/kiibohd/kll/commit/1a078b2b940709bc3c429c952d2f0d842927394f