### PR TITLE
[Proposal] Add layerDelayedLock capability

### DIFF
--- a/Macro/PartialMap/capabilities.kll
+++ b/Macro/PartialMap/capabilities.kll
@@ -11,6 +11,7 @@ Date = 2016-04-08;
 layerState  => Macro_layerState_capability( layer : 2, state : 1 );
 layerLatch  => Macro_layerLatch_capability( layer : 2 );
 layerLock   => Macro_layerLock_capability( layer : 2 );
+layerDelayedLock => Macro_layerDelayedLock_capability( layer : 2 );
 layerShift  => Macro_layerShift_capability( layer : 2 );
 # By default, rotate to the next layer
 # The current rotating layer is stored separately to the layer stack

--- a/Macro/PartialMap/macro.c
+++ b/Macro/PartialMap/macro.c
@@ -293,6 +293,35 @@ void Macro_layerLock_capability( uint8_t state, uint8_t stateType, uint8_t *args
 	Macro_layerState( state, stateType, layer, 0x04 );
 }
 
+uint32_t layerDelayedLock_timer = 0;
+uint8_t layerDelayedLock_alreadySwitched = 0;
+// Locks given layer after it's been pressed for 500 milliseconds
+// Argument #1: Layer Index -> uint16_t
+void Macro_layerDelayedLock_capability( uint8_t state, uint8_t stateType, uint8_t *args ) {
+	// Display capability name
+	if ( stateType == 0xFF && state == 0xFF ) {
+		print("Macro_layerDelayedLock_capability(layerIndex)");
+		return;
+	}
+
+	uint32_t currentTime = systick_millis_count;
+	if ( stateType == 0x00 && state == 0x01 ) { // Pressed
+		layerDelayedLock_timer = currentTime; // Set start timestamp
+		layerDelayedLock_alreadySwitched = 0;
+	} else if ( stateType == 0x00 && state == 0x02 && !layerDelayedLock_alreadySwitched) { // Hold
+		int32_t diff = (int32_t)(currentTime - layerDelayedLock_timer);
+		if (diff > 500) { // TODO: Make customizable
+			// We reached the threshold
+			// Get layer index from arguments
+			// Cast pointer to uint8_t to uint16_t then access that memory location
+			uint16_t layer = *(uint16_t*)(&args[0]);
+			Macro_layerState( state, stateType, layer, 0x04 );
+			layerDelayedLock_alreadySwitched = 1;
+			layerDelayedLock_timer = 0;
+		}
+	}
+}
+
 
 // Shifts given layer
 // Argument #1: Layer Index -> uint16_t


### PR DESCRIPTION
This adds a capability to switch between layers that acts like a 'lock'
but with the difference that it requires the 'lock' key to be pressed
for 500 milliseconds before the function layer gets locked.

This is useful to avoid switching to a function layer by mistake since
pressing the lock key by accident won't actually switch layer unless
it's held for at least 500ms. (and yes an improvement would be to make those 500 milliseconds customizable).

So essentially:
 - Keyboard is in default layer 0.
 - User presses layerDelayedLock(1) key
    - If the user releases the 'delayed lock' key before 500 milliseconds, nothing happens, the current layer will still be layer 0.
    - If a new key is pressed before 500 milliseconds, the key press will still be from layer 0.
 - After 500 milliseconds have elapsed since the 'delayed lock' key was pressed then the keyboard locks to layer 1
- The same behaviour applies to unlock the layer.

---

This is a proposal, perhaps it's not the best way to implement it but I've been using it on a daily basis for about a month now and it works well for me. Feel free to close the PR if you don't think this feature fits well in the project.

Also note that I don't usually code in C/C++ so this can probably be improved by someone with more knowledge. 