### PR TITLE
Treating modifier keys in a  Macro combination as ghostkey

### DIFF
--- a/Macro/PartialMap/kll.h
+++ b/Macro/PartialMap/kll.h
@@ -109,6 +109,11 @@ typedef struct ResultGuide {
 	uint8_t args; // This is used as an array pointer (but for packing purposes, must be 8 bit)
 } ResultGuide;
 
+#define KEY_TYPE_GHOST 0xC0
+
+#define KEY_TYPE_NORMAL 0x00
+#define KEY_TYPE_LED	0x01
+#define KEY_TYPE_ANALOG 0x02
 
 
 // -- Trigger Macro
@@ -119,6 +124,10 @@ typedef struct ResultGuide {
 //   * 0x01 LED State (On/Off)
 //   * 0x02 Analog (Threshold)
 //   * 0x03-0xFE Reserved
+//   * 0xCX Ghost Key 
+//   * -- 0xC0 Normal
+//   * -- 0xC1 LED State 
+//   * -- 0xC2 Analog 
 //   * 0xFF Debug State
 //
 // Key State:

--- a/Macro/PartialMap/result.c
+++ b/Macro/PartialMap/result.c
@@ -88,7 +88,7 @@ inline ResultMacroEval Macro_evalResultMacro( var_uint_t resultMacroIndex )
 		void (*capability)(uint8_t, uint8_t, uint8_t*) = (void(*)(uint8_t, uint8_t, uint8_t*))(CapabilitiesList[ guide->index ].func);
 
 		// Call capability
-		capability( record->state, record->stateType, &guide->args );
+		capability( record->state, record->stateType | (comboLength > 1?KEY_TYPE_GHOST:0x00), &guide->args );
 
 		// Increment counters
 		funcCount++;

--- a/Output/pjrcUSB/output_com.c
+++ b/Output/pjrcUSB/output_com.c
@@ -417,6 +417,17 @@ void Output_usbCodeSend_capability( uint8_t state, uint8_t stateType, uint8_t *a
 		break;
 
 	case 1: // NKRO Mode
+		if ( keyPress && ! is_ghost_key && USBKeys_Modifiers ^ USBKeys_ModifiersManual){
+			if( Output_DebugMode){
+				dbug_msg("plain key pressed, modifiers=");
+				printHex(USBKeys_Modifiers);
+				print(" ,modifiers_manual=");
+				printHex(USBKeys_ModifiersManual);
+				print(NL);
+			}
+			USBKeys_Modifiers = USBKeys_ModifiersManual;
+			USBKeys_Changed |= USBKeyChangeState_Modifiers;
+		}
 		// Set the modifier bit if this key is a modifier
 		if ( (key & 0xE0) == 0xE0 ) // AND with 0xE0 (Left Ctrl, first modifier)
 		{
@@ -437,9 +448,12 @@ void Output_usbCodeSend_capability( uint8_t state, uint8_t stateType, uint8_t *a
 					printHex(key);
 					print(" state=");
 					printHex(state);
+					printHex(USBKeys_Modifiers);
+					print("/");
+					printHex(USBKeys_ModifiersManual);
 					print(NL);
 				}
-				if ( (USBKeys_ModifiersManual & USBKeys_Modifiers) == USBKeys_ModifiersManual){
+				if ( USBKeys_Modifiers >= USBKeys_ModifiersManual){
 					USBKeys_Changed |= USBKeyChangeState_Modifiers;
 				}else{
 					USBKeys_Modifiers = USBKeys_ModifiersManual;


### PR DESCRIPTION
A `GhostKey` is defined as a key event that is triggered in a macro combination.
The `GhostKey` should not influence other key event that not included in this macro combination.
Which means the `GhostKey` only affects the keys in same macro combination.
```
Since the current kll spec does not have a `GhostKey` concept. 
So, this impl will preventing mapping multiple modifier event on single key strike.
```