### PR TITLE
Added logic to avoid layer shifts causing a layer to be stuck on

### DIFF
--- a/Macro/PartialMap/macro.c
+++ b/Macro/PartialMap/macro.c
@@ -314,6 +314,14 @@ void Macro_layerShift_capability( uint8_t state, uint8_t stateType, uint8_t *arg
 	// Cast pointer to uint8_t to uint16_t then access that memory location
 	uint16_t layer = *(uint16_t*)(&args[0]);
 
+	// Only set the layer if it is disabled
+	if ( LayerState[ layer ] != 0x00 && state == 0x01 )
+		return;
+
+	// Only unset the layer if it is enabled
+	if ( LayerState[ layer ] == 0x00 && state == 0x03 )
+		return;
+
 	Macro_layerState( state, stateType, layer, 0x01 );
 }
 
@@ -1356,4 +1364,3 @@ void cliFunc_macroStep( char* args )
 	// Set the macro step counter, negative int's are cast to uint
 	macroStepCounter = count;
 }
-


### PR DESCRIPTION
This addresses issue #66 and resolves that issue. Now, I cannot use layer shifts to cause a layer to be stuck on.