### PR TITLE
Disable debug console by default and enable it with a new module

### DIFF
--- a/Debug/debugconsole/setup.cmake
+++ b/Debug/debugconsole/setup.cmake
@@ -1,0 +1,28 @@
+###| CMake Kiibohd Controller Debug Module |###
+#
+# Written by Jacob Alexander in 2011-2015 for the Kiibohd Controller
+#
+# Released into the Public Domain
+#
+###
+
+
+###
+# Required Submodules
+#
+
+AddModule ( Debug cli )
+AddModule ( Debug led )
+AddModule ( Debug print )
+
+add_definitions(-DDEBUG)
+
+
+###
+# Compiler Family Compatibility
+#
+set ( ModuleCompatibility
+	arm
+	avr
+)
+

--- a/main.c
+++ b/main.c
@@ -45,8 +45,10 @@ int main()
 	CLKPR = 0x00;
 #endif
 
+#if defined(DEBUG)
 	// Enable CLI
 	CLI_init();
+#endif
 
 	// Setup Modules
 	Output_setup();
@@ -56,8 +58,10 @@ int main()
 	// Main Detection Loop
 	while ( 1 )
 	{
+#if defined(DEBUG)
 		// Process CLI
 		CLI_process();
+#endif
 
 		// Acquire Key Indices
 		// Loop continuously until scan_loop returns 0


### PR DESCRIPTION
As I wrote on #159 , having this on by default is a security risk, especially for OS X users. This fix works on my machine and appears to disable it. I'm not familiar enough with the firmware to know if there is more risk lurking elsewhere in the firmware, but this at least removes one obvious attack users could suffer from.

To enable the console, one simply changes their build script to have the following variable: `DebugModule="debugconsole"`

With `DebugModule="full"`, the debug console will be disabled.