### PR TITLE
Caps-lock controls LCD backlight

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:xenial
+
+RUN apt-get update
+RUN apt-get install -y git cmake ctags tmux
+RUN apt-get install -y libusb-1.0-0-dev binutils-arm-none-eabi gcc-arm-none-eabi libnewlib-arm-none-eabi dfu-util
+RUN apt-get install -y python3 python3-pil

--- a/Scan/STLcd/lcd_scan.c
+++ b/Scan/STLcd/lcd_scan.c
@@ -338,12 +338,13 @@ inline void LCD_setup()
 	PORTC_PCR3 = PORT_PCR_SRE | PORT_PCR_DSE | PORT_PCR_MUX(4);
 }
 
-uint16_t hold_color[3];
-uint8_t was_capslock = 0;
 
 // LCD State processing loop
 inline uint8_t LCD_scan()
 {
+  static uint16_t hold_color[3];
+  static uint8_t was_capslock = 0;
+
   uint16_t is_capslock = USBKeys_LEDs & 2;
 
   if (is_capslock && !was_capslock) {

--- a/Scan/STLcd/lcd_scan.c
+++ b/Scan/STLcd/lcd_scan.c
@@ -338,11 +338,37 @@ inline void LCD_setup()
 	PORTC_PCR3 = PORT_PCR_SRE | PORT_PCR_DSE | PORT_PCR_MUX(4);
 }
 
+uint16_t hold_color[3];
+uint8_t was_capslock = 0;
 
 // LCD State processing loop
 inline uint8_t LCD_scan()
 {
-	return 0;
+  uint16_t is_capslock = USBKeys_LEDs & 2;
+
+  if (is_capslock && !was_capslock) {
+    // entering capslock state
+    was_capslock = 1;
+
+    hold_color[0] = FTM0_C0V;
+    hold_color[1] = FTM0_C1V;
+    hold_color[2] = FTM0_C2V;
+  }
+  else if (!is_capslock && was_capslock) {
+    was_capslock = 0;
+
+    FTM0_C0V = hold_color[0];
+    FTM0_C1V = hold_color[1];
+    FTM0_C2V = hold_color[2];
+  }
+
+  if (is_capslock) {
+    FTM0_C0V = 0x8303;
+    FTM0_C1V = 0x1394;
+    FTM0_C2V = 0xb9f9;
+  }
+
+  return 0;
 }
 
 

--- a/Scan/STLcd/lcd_scan.c
+++ b/Scan/STLcd/lcd_scan.c
@@ -340,7 +340,7 @@ inline void LCD_setup()
 
 
 // LCD State processing loop
-inline void check_caps_lock()
+static inline void check_caps_lock()
 {
 	static uint16_t hold_color[3];
 	static uint8_t was_capslock = 0;

--- a/Scan/STLcd/lcd_scan.c
+++ b/Scan/STLcd/lcd_scan.c
@@ -340,38 +340,44 @@ inline void LCD_setup()
 
 
 // LCD State processing loop
-inline uint8_t LCD_scan()
+inline void check_caps_lock()
 {
-  static uint16_t hold_color[3];
-  static uint8_t was_capslock = 0;
+	static uint16_t hold_color[3];
+	static uint8_t was_capslock = 0;
 
-  uint16_t is_capslock = USBKeys_LEDs & 2;
+	uint16_t is_capslock = USBKeys_LEDs & 2;
 
-  if (is_capslock && !was_capslock) {
-    // entering capslock state
-    was_capslock = 1;
+	if ( is_capslock && !was_capslock )
+	{
+		// entering capslock state
+		was_capslock = 1;
 
-    hold_color[0] = FTM0_C0V;
-    hold_color[1] = FTM0_C1V;
-    hold_color[2] = FTM0_C2V;
-  }
-  else if (!is_capslock && was_capslock) {
-    was_capslock = 0;
+		hold_color[0] = FTM0_C0V;
+		hold_color[1] = FTM0_C1V;
+		hold_color[2] = FTM0_C2V;
+	}
+	else if ( !is_capslock && was_capslock )
+	{
+		was_capslock = 0;
 
-    FTM0_C0V = hold_color[0];
-    FTM0_C1V = hold_color[1];
-    FTM0_C2V = hold_color[2];
-  }
+		FTM0_C0V = hold_color[0];
+		FTM0_C1V = hold_color[1];
+		FTM0_C2V = hold_color[2];
+	}
 
-  if (is_capslock) {
-    FTM0_C0V = 0x8303;
-    FTM0_C1V = 0x1394;
-    FTM0_C2V = 0xb9f9;
-  }
-
-  return 0;
+	if ( is_capslock )
+	{
+		FTM0_C0V = 0x8303;
+		FTM0_C1V = 0x1394;
+		FTM0_C2V = 0xb9f9;
+	}
 }
 
+inline uint8_t LCD_scan()
+{
+	check_caps_lock();
+	return 0;
+}
 
 // Signal from parent Scan Module that available current has changed
 // current - mA


### PR DESCRIPTION
I used the caps-lock feature in https://github.com/kiibohd/controller/issues/117 for about a day, and left a bit dissatisfied that the layout maintains its own caps-lock state which can get out of sync with the host. This is a first and kinda sloppy pass at a better way of exposing caps-lock status through the LCD module.

On every scan interval, it grabs the caps lock state from the `USBKeys_LEDs` variable, and determines if caps-lock is coming on or turning off. If it's turning on, it stores the existing backlight color register values. If it's turning off, it restores the saved color registers. If caps-lock is on, it plugs a hard-coded "Fanta Purple" color in to those registers on every scan, with the goal that it'll clobber layer-caused changes to the backlight pretty quickly (I can still see flicker though :( )

This is my first time writing keyboard firmware, and to start with, this isn't really configurable at all, so it probably shouldn't be accepted as-is :) Comments, improvements, and changes are appreciated.