### PR TITLE
Drop packet upon wakeup

### DIFF
--- a/Output/pjrcUSB/arm/usb_dev.c
+++ b/Output/pjrcUSB/arm/usb_dev.c
@@ -1132,7 +1132,7 @@ void usb_rx_memory( usb_packet_t *packet )
 }
 
 // Call whenever there's an action that may wake the host device
-void usb_resume()
+uint8_t usb_resume()
 {
 	// If we have been sleeping, try to wake up host
 	if ( usb_dev_sleep && usb_configured() )
@@ -1151,8 +1151,11 @@ void usb_resume()
 		#else
 		warn_print("Host Resume Disabled");
 		#endif
+
+		return 1;
 	}
 
+	return 0;
 }
 
 void usb_tx( uint32_t endpoint, usb_packet_t *packet )

--- a/Output/pjrcUSB/arm/usb_dev.h
+++ b/Output/pjrcUSB/arm/usb_dev.h
@@ -63,7 +63,7 @@ void usb_isr();
 void usb_tx( uint32_t endpoint, usb_packet_t *packet );
 void usb_tx_isr( uint32_t endpoint, usb_packet_t *packet );
 
-void usb_resume();
+uint8_t usb_resume();
 
 uint32_t usb_tx_byte_count( uint32_t endpoint );
 uint32_t usb_tx_packet_count( uint32_t endpoint );

--- a/Output/pjrcUSB/arm/usb_keyboard.c
+++ b/Output/pjrcUSB/arm/usb_keyboard.c
@@ -97,7 +97,12 @@ void usb_keyboard_send()
 		}
 
 		// Try to wake up the host if it's asleep
-		usb_resume();
+		if ( usb_resume() )
+		{
+			// Drop packet
+			USBKeys_Changed = USBKeyChangeState_None;
+			return;
+		}
 
 		if ( USBKeys_Protocol == 0 ) // Boot Mode
 		{


### PR DESCRIPTION
The key press used to resume seems to "fall through" and make it to whatever application was focused when the system was put to sleep, drop the packet to prevent that.

Might be related to #75.