### PR TITLE
Consider the system awake while we're receiving SOF tokens

### DIFF
--- a/Output/pjrcUSB/arm/usb_dev.c
+++ b/Output/pjrcUSB/arm/usb_dev.c
@@ -1268,6 +1268,14 @@ restart:
 			#endif
 
 		}
+
+		// SOF tokens are used for keepalive, consider the system awake when we're receiving them
+		if ( usb_dev_sleep )
+		{
+			Output_update_usb_current( *usb_bMaxPower * 2 );
+			usb_dev_sleep = 0;
+		}
+
 		USB0_ISTAT = USB_INTEN_SOFTOKEN;
 	}
 


### PR DESCRIPTION
More USB resume stuff.

This is a strange edge case I've seen on my system, which seems related to DRAM setup on the host, but that's pretty irrelevant here. What happens is that during bootup, transitions from kernel to kernel (ie UEFI => refind => Linux) or resume from S3, the USB controller stops sending SOFs, misleading the firmware into thinking that we went back to sleep. Since we don't get a resume signal after this condition but the controller resumes normal operation, sending more resume signals at this point can cause weird behavior. It's safe to assume SOF = awake (that's what the USB spec says anyway), so this fixes it.  
I haven't been able to reproduce this behavior with other HIDs.

Hopefully resume should be fully ironed out now, I'll come back with more stuff if I come across another bug.