### PR TITLE
Mention MD1/MD1.1 names in addition to 'Infinity 60%'

### DIFF
--- a/Keyboards/README.markdown
+++ b/Keyboards/README.markdown
@@ -27,8 +27,8 @@ Example
 Projects
 --------
 
-* infinity.bash     (Infinity Keyboard 2014/10/15)
-* infinity_led.bash (Infinity Keyboard with LED backlight support)
+* infinity.bash     (Infinity Keyboard 2014/10/15 (MD1))
+* infinity_led.bash (Infinity Keyboard with LED backlight support (MD1.1))
 * ergodox.bash      (Infinity Ergodox 2015/08/15)
 * template.bash     (Example template for new keyboards)
 * whitefox.bash     (WhiteFox Keyboard)

--- a/Keyboards/ergodox.bash
+++ b/Keyboards/ergodox.bash
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# This is a build script template
+#
+# Keyboard: Ergodox
+#
 # These build scripts are just a convenience for configuring your keyboard (less daunting than CMake)
 # Jacob Alexander 2015-2016
 

--- a/Keyboards/infinity.bash
+++ b/Keyboards/infinity.bash
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# This is a build script template
+#
+# Keyboard: Infinity 60% (MD1)
+#
 # These build scripts are just a convenience for configuring your keyboard (less daunting than CMake)
 # Jacob Alexander 2015-2016
 

--- a/Keyboards/infinity_led.bash
+++ b/Keyboards/infinity_led.bash
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# This is a build script template
+#
+# Keyboard: Infinity 60% with LED backlight support (MD1.1)
+#
 # These build scripts are just a convenience for configuring your keyboard (less daunting than CMake)
 # Jacob Alexander 2016
 

--- a/Keyboards/template.bash
+++ b/Keyboards/template.bash
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# This is a build script template
+#
+# Keyboard: (template)
+#
 # These build scripts are just a convenience for configuring your keyboard (less daunting than CMake)
 # Jacob Alexander 2015-2016
 

--- a/Keyboards/whitefox.bash
+++ b/Keyboards/whitefox.bash
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# This is a build script template
+#
+# Keyboard: WhiteFox
+#
 # These build scripts are just a convenience for configuring your keyboard (less daunting than CMake)
 # Jacob Alexander 2015-2016
 


### PR DESCRIPTION
The online configurator still mentions the MD1 and MD1.1 names, while master
only talks about 'Infinity 60%' and 'Infinity 60% with LED backlight
support'. Try to avoid confusion by mentioning both names, both in the
README as in the build scripts.

---
I lost some time due to having created my custom layout based on IC60 while I should have used IC60_LED. It was not fully clear how these mapped onto the names used in the online configurator.