### PR TITLE
create datastream handler and process a0 bit.

### DIFF
--- a/Scan/STLcd/lcd_scan.c
+++ b/Scan/STLcd/lcd_scan.c
@@ -610,31 +610,32 @@ void cliFunc_lcdCmd( char* args )
 
 	// No args
 	if ( *arg1Ptr == '\0' )
-        {
-            print("No args provided.");
-            print( NL );
-	    return;
-        }
+    {
+		print("No args provided.");
+		print( NL );
+		return;
+    }
 	// SPI Command
 	uint8_t cmd = (uint8_t)numToInt( arg1Ptr );
 
 	// Single Arg
-        if ( *arg2Ptr == '\0' )
-        {
-            info_msg("Sending- ");
-            printHex( cmd );
-            print( NL );
-            LCD_writeControlReg( cmd );
-            return;
-        }
+	if ( *arg2Ptr == '\0' )
+	{
+        info_msg("Sending- ");
+		printHex( cmd );
+		print( NL );
+		LCD_writeControlReg( cmd );
+		return;
+	}
 
-	if ( *arg2Ptr != '\0' ) {
-            info_msg("Sending WITH A0 FLAG SET- ");
-            printHex( cmd );
-            print( NL );
-            LCD_writeDataReg( cmd );
-            return;
-        }
+	if ( *arg2Ptr != '\0' ) 
+	{
+		info_msg("Sending WITH A0 FLAG SET- ");
+		printHex( cmd );
+		print( NL );
+		LCD_writeDataReg( cmd );
+		return;
+    }
 
 }
 

--- a/Scan/STLcd/lcd_scan.c
+++ b/Scan/STLcd/lcd_scan.c
@@ -609,16 +609,18 @@ void cliFunc_lcdCmd( char* args )
 	CLI_argumentIsolation( curArgs, &arg1Ptr, &arg2Ptr );
 
 	// No args
-	if ( *arg1Ptr == '\0' ) {
-                print("No args provided.");
-                print( NL );
-		return;
+	if ( *arg1Ptr == '\0' )
+        {
+            print("No args provided.");
+            print( NL );
+	    return;
         }
 	// SPI Command
 	uint8_t cmd = (uint8_t)numToInt( arg1Ptr );
 
 	// Single Arg
-        if ( *arg2Ptr == '\0' ) {
+        if ( *arg2Ptr == '\0' )
+        {
             info_msg("Sending- ");
             printHex( cmd );
             print( NL );
@@ -629,8 +631,8 @@ void cliFunc_lcdCmd( char* args )
 	if ( *arg2Ptr != '\0' ) {
             info_msg("Sending WITH A0 FLAG SET- ");
             printHex( cmd );
-            print(NL);
-            LCD_writeDataReg(cmd);
+            print( NL );
+            LCD_writeDataReg( cmd );
             return;
         }
 


### PR DESCRIPTION
added a separate function to handle datastreams.

handle `lcdCmd <cmd> <a0>` rather then ignoring it.

Signed-off-by: Joshua Schmid <jschmid@suse.de>