### PR TITLE
Rapoo E9070 keyboard added

### DIFF
--- a/Keyboards/Rapoo_E9070.bash
+++ b/Keyboards/Rapoo_E9070.bash
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Keyboard: (template)
+#
+# These build scripts are just a convenience for configuring your keyboard (less daunting than CMake)
+# Jacob Alexander 2015-2016
+
+
+
+#################
+# Configuration #
+#################
+
+# Feel free to change the variables in this section to configure your keyboard
+
+BuildPath="Rapoo_E9070"
+
+## KLL Configuration ##
+
+# Generally shouldn't be changed, this will affect every layer
+BaseMap="scancode_map"
+
+# This is the default layer of the keyboard
+# NOTE: To combine kll files into a single layout, separate them by spaces
+# e.g.  DefaultMap="mylayout mylayoutmod"
+DefaultMap="stdFuncMap"
+
+# This is where you set the additional layers
+# NOTE: Indexing starts at 1
+# NOTE: Each new layer is another array entry
+# e.g.  PartialMaps[1]="layer1 layer1mod"
+#       PartialMaps[2]="layer2"
+#       PartialMaps[3]="layer3"
+PartialMaps[1]="Rapoo_E9070_Fn"
+
+
+
+##########################
+# Advanced Configuration #
+##########################
+
+# Don't change the variables in this section unless you know what you're doing
+# These are useful for completely custom keyboards
+# NOTE: Changing any of these variables will require a force build to compile correctly
+
+# Keyboard Module Configuration
+ScanModule="Rapoo_E9070"
+MacroModule="PartialMap"
+OutputModule="pjrcUSB"
+DebugModule="full"
+
+# Microcontroller
+Chip="mk20dx256"
+
+# Compiler Selection
+Compiler="gcc"
+
+
+
+########################
+# Bash Library Include #
+########################
+
+# Shouldn't need to touch this section
+
+# Check if the library can be found
+if [ ! -f cmake.bash ]; then
+	echo "ERROR: Cannot find 'cmake.bash'"
+	exit 1
+fi
+
+# Load the library
+source cmake.bash
+

--- a/Scan/Rapoo_E9070/matrix.h
+++ b/Scan/Rapoo_E9070/matrix.h
@@ -1,0 +1,50 @@
+/*
+ * Configured by Nazar Mokrynskyi
+ *
+ * License: Public Domain
+ */
+
+#pragma once
+
+// ----- Includes -----
+
+// Project Includes
+#include <matrix_setup.h>
+
+/**
+ * ----- Matrix Definition -----
+ *  Rapoo E9070
+ *  Columns (Strobe)  19
+ *  Rows    (Sense)   8
+ *
+ * Keyboard loop only contains 17 lanes, but PCB has 19 labeled contacts, so let's assume there are 19 of them
+ * and connect all for the sake of simplicity.
+ * Also matrixInfo only reports 13 columns, so I have no idea what wires from those 19 are actually required,
+ * but it works when all of them are connected, so I didn't bother checking this.
+ */
+
+/**
+ * Pins on Teensy 3.2     : 0   1   2   3   4   5   6   7   8   9   10   11   12   24   25   26   27   28   29
+ * Pins on keyboard's PCB : KC0 KC1 KC2 KC3 KC4 KC5 KC6 KC7 KC8 KC9 KC10 KC11 KC12 KC13 KC14 KC15 KC16 KC17 KC18
+ */
+GPIO_Pin Matrix_cols[] = {
+  gpio(B,16), gpio(B,17), gpio(D,0), gpio(A,12), gpio(A,13), gpio(D,7), gpio(D,4), gpio(D,2), gpio(D,3), gpio(C,3),
+  gpio(C,4), gpio(C,6), gpio(C,7), gpio(A,5), gpio(B,19), gpio(E,1), gpio(C,9), gpio(C,8), gpio(C,10)
+};
+/**
+ * Pins on Teensy 3.2     : 21  20  19  18  17  16  15  14
+ * Pins on keyboard's PCB : KR0 KR1 KR2 KR3 KR4 KR5 KR6 KR7
+ */
+GPIO_Pin Matrix_rows[] = {
+  gpio(D,6), gpio(D,5), gpio(B,2), gpio(B,3), gpio(B,1), gpio(B,0), gpio(C,0), gpio(D,1)
+};
+
+// Define type of scan matrix
+Config Matrix_type = Config_Pullup;
+
+// Define this if your matrix has ghosting (i.e. regular keyboard without diodes)
+// this will enable the anti-ghosting code
+#define GHOSTING_MATRIX
+
+// delay in microseconds before and after each strobe change during matrix scan
+#define STROBE_DELAY  10

--- a/Scan/Rapoo_E9070/scan_loop.c
+++ b/Scan/Rapoo_E9070/scan_loop.c
@@ -1,0 +1,216 @@
+/* Copyright (C) 2014-2017 by Jacob Alexander
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// ----- Includes -----
+
+// Compiler Includes
+#include <Lib/ScanLib.h>
+
+// Project Includes
+#include <cli.h>
+#include <led.h>
+#include <print.h>
+#include <matrix_scan.h>
+#include <macro.h>
+
+// KLL Include
+#include <kll.h>
+
+// Local Includes
+#include "scan_loop.h"
+
+
+
+// ----- Function Declarations -----
+
+// CLI Functions
+void cliFunc_echo( char* args );
+
+
+
+// ----- Variables -----
+
+// Scan Module command dictionary
+CLIDict_Entry( echo,        "Example command, echos the arguments." );
+
+CLIDict_Def( scanCLIDict, "Scan Module Commands" ) = {
+	CLIDict_Item( echo ),
+	{ 0, 0, 0 } // Null entry for dictionary end
+};
+
+// Number of scans since the last USB send
+uint16_t Scan_scanCount = 0;
+
+
+
+// ----- Functions -----
+
+// Setup
+inline void Scan_setup()
+{
+	// Register Scan CLI dictionary
+	CLI_registerDictionary( scanCLIDict, scanCLIDictName );
+
+	// Setup GPIO pins for matrix scanning
+	Matrix_setup();
+
+	// Reset scan count
+	Scan_scanCount = 0;
+}
+
+
+// Main Detection Loop
+inline uint8_t Scan_loop()
+{
+	Matrix_scan( Scan_scanCount++ );
+
+	return 0;
+}
+
+
+// Signal from Macro Module that all keys have been processed (that it knows about)
+inline void Scan_finishedWithMacro( uint8_t sentKeys )
+{
+}
+
+
+// Signal from Output Module that all keys have been processed (that it knows about)
+inline void Scan_finishedWithOutput( uint8_t sentKeys )
+{
+	// Reset scan loop indicator (resets each key debounce state)
+	// TODO should this occur after USB send or Macro processing?
+	Scan_scanCount = 0;
+}
+
+
+
+// ----- Capabilities -----
+
+// Custom capability examples
+// Refer to kll.h in Macros/PartialMap for state and stateType information
+void CustomAction_action1_capability( TriggerMacro *trigger, uint8_t state, uint8_t stateType, uint8_t *args )
+{
+	// Display capability name
+	// XXX This is required for debug cli to give you a list of capabilities
+	if ( stateType == 0xFF && state == 0xFF )
+	{
+		print("CustomAction_action1_capability()");
+		return;
+	}
+
+	// Prints Action1 info message to the debug cli
+	info_print("Action1");
+}
+
+uint8_t CustomAction_blockHold_storage = 0;
+void CustomAction_blockHold_capability( TriggerMacro *trigger, uint8_t state, uint8_t stateType, uint8_t *args )
+{
+	// Display capability name
+	if ( stateType == 0xFF && state == 0xFF )
+	{
+		print("CustomAction_blockHold_capability(usbCode)");
+		return;
+	}
+
+	// Retrieve 8-bit argument
+	uint8_t key = args[0];
+
+	// We only care about normal keys
+	if ( stateType == 0x00 )
+	{
+		// Block given key if we're in the "Press" or "Hold" state
+		if ( ( state == 0x01 || state == 0x02 )
+			&& CustomAction_blockHold_storage == 0 )
+		{
+			CustomAction_blockHold_storage = key;
+			info_msg("Blocking Key: ");
+			printHex( key );
+			print( NL );
+		}
+		// Release if in the "Off" or "Release" state and we're blocking
+		else if ( ( state == 0x00 || state == 0x03 )
+			&& key == CustomAction_blockHold_storage )
+		{
+			info_msg("Unblocking Key: ");
+			printHex( CustomAction_blockHold_storage );
+			print( NL );
+			CustomAction_blockHold_storage = 0;
+		}
+	}
+}
+
+void CustomAction_blockKey_capability( TriggerMacro *trigger, uint8_t state, uint8_t stateType, uint8_t *args )
+{
+	// Display capability name
+	if ( stateType == 0xFF && state == 0xFF )
+	{
+		print("CustomAction_blockKey_capability(usbCode)");
+		return;
+	}
+
+	// Retrieve 8-bit argument
+	uint8_t key = args[0];
+
+	// If key is not blocked, process
+	if ( key != CustomAction_blockHold_storage )
+	{
+		extern void Output_usbCodeSend_capability( TriggerMacro *trigger, uint8_t state, uint8_t stateType, uint8_t *args );
+		Output_usbCodeSend_capability( trigger, state, stateType, &key );
+	}
+}
+
+
+// Signal from the Output Module that the available current has changed
+// current - mA
+void Scan_currentChange( unsigned int current )
+{
+	// Indicate to all submodules current change
+	Matrix_currentChange( current );
+}
+
+
+
+// ----- CLI Command Functions -----
+
+// XXX Just an example command showing how to parse arguments (more complex than generally needed)
+void cliFunc_echo( char* args )
+{
+	char* curArgs;
+	char* arg1Ptr;
+	char* arg2Ptr = args;
+
+	// Parse args until a \0 is found
+	while ( 1 )
+	{
+		print( NL ); // No \r\n by default after the command is entered
+
+		curArgs = arg2Ptr; // Use the previous 2nd arg pointer to separate the next arg from the list
+		CLI_argumentIsolation( curArgs, &arg1Ptr, &arg2Ptr );
+
+		// Stop processing args if no more are found
+		if ( *arg1Ptr == '\0' )
+			break;
+
+		// Print out the arg
+		dPrint( arg1Ptr );
+	}
+}
+

--- a/Scan/Rapoo_E9070/scan_loop.h
+++ b/Scan/Rapoo_E9070/scan_loop.h
@@ -1,0 +1,42 @@
+/* Copyright (C) 2014-2016 by Jacob Alexander
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+// ----- Includes -----
+
+// Compiler Includes
+#include <stdint.h>
+
+
+
+// ----- Functions -----
+
+// Functions to be called by main.c
+void Scan_setup( void );
+uint8_t Scan_loop( void );
+
+// Call-backs
+void Scan_finishedWithMacro( uint8_t sentKeys );  // Called by Macro Module
+void Scan_finishedWithOutput( uint8_t sentKeys ); // Called by Output Module
+
+void Scan_currentChange( unsigned int current ); // Called by Output Module
+

--- a/Scan/Rapoo_E9070/scancode_map.kll
+++ b/Scan/Rapoo_E9070/scancode_map.kll
@@ -1,0 +1,118 @@
+Name = "Rapoo E9070";
+Version = 0.1;
+Author = "nazar-pc (Nazar Mokrynskyi) 2017";
+KLL = 0.3d;
+
+# Modified Date
+Date = 2017-05-25;
+
+# Each group is one row of keys on keyboard starting from the top
+# Comments are added where layout differs on ANSI and ISO layouts
+S0x3A : U"Esc";
+S0x74 : U"F1";
+S0x75 : U"F2";
+S0x16 : U"F3";
+S0x3C : U"F4";
+S0x85 : U"F5";
+S0x3F : U"F6";
+S0x1A : U"F7";
+S0x79 : U"F8";
+S0x7C : U"F9";
+S0x8F : U"F10";
+S0x43 : U"F11";
+S0x69 : U"F12";
+S0x8E : U"PrintScreen";
+S0x00 : U"Pause";
+S0x7E : U"Insert";
+S0x7D : U"Delete";
+S0x57 : U"NumLock";
+S0x58 : U"Keypad Slash";
+S0x59 : U"Keypad Asterix";
+
+S0x73 : U"Backtick";
+S0x86 : U"1";
+S0x87 : U"2";
+S0x88 : U"3";
+S0x89 : U"4";
+S0x76 : U"5";
+S0x77 : U"6";
+S0x8A : U"7";
+S0x8B : U"8";
+S0x8C : U"9";
+S0x8D : U"0";
+S0x7A : U"-";
+S0x78 : U"=";
+S0x1D : U"Backspace";
+S0x46 : U"Keypad Decimal";
+S0x0E : U"Keypad Plus";
+S0x6C : U"Keypad Minus";
+
+S0x14 : U"Tab";
+S0x01 : U"q";
+S0x02 : U"w";
+S0x03 : U"e";
+S0x04 : U"r";
+S0x17 : U"t";
+S0x18 : U"y";
+S0x05 : U"u";
+S0x06 : U"i";
+S0x07 : U"o";
+S0x08 : U"p";
+S0x1B : U"[";
+S0x19 : U"]";
+S0x30 : U"\"; # In this row on ANSI layout, but below on ISO, code is also different on ISO
+S0x0B : U"Keypad 7";
+S0x0C : U"Keypad 8";
+S0x0D : U"Keypad 9";
+
+S0x56 : U"Enter"; # Between rows on ISO layout, but on next row in ANSI
+
+S0x15 : U"CapsLock";
+S0x27 : U"a";
+S0x28 : U"s";
+S0x29 : U"d";
+S0x2A : U"f";
+S0x3D : U"g";
+S0x3E : U"h";
+S0x2B : U"j";
+S0x2C : U"k";
+S0x2D : U"l";
+S0x2E : U";";
+S0x41 : U"'";
+S0x54 : U"\"; # In this row ISO layout, but above on ANSI
+S0x56 : U"Enter"; # In this row on ANSI layout, but above on ISO
+S0x1E : U"Keypad 4";
+S0x1F : U"Keypad 5";
+S0x20 : U"Keypad 6";
+
+S0x22 : U"LShift";
+S0x3B : U"ISO Slash"; # Not present here on ANSI layout
+S0x4D : U"z";
+S0x4E : U"x";
+S0x4F : U"c";
+S0x50 : U"v";
+S0x63 : U"b";
+S0x64 : U"n";
+S0x51 : U"m";
+S0x52 : U",";
+S0x53 : U".";
+S0x67 : U"/";
+S0x35 : U"RShift";
+S0x31 : U"Keypad 1";
+S0x32 : U"Keypad 2";
+S0x33 : U"Keypad 3";
+
+S0x72 : U"LCtrl";
+S0x2F : U"Function1";
+S0x23 : U"LGui";
+S0x42 : U"LAlt";
+S0x44 : U"Space";
+S0x68 : U"RAlt";
+S0x66 : SYS"ContextMenu";
+S0x4C : U"RCtrl";
+S0x6D : U"Left";
+S0x47 : U"Up";
+S0x6A : U"Down";
+S0x6B : U"Right";
+S0x45 : U"Keypad 0";
+S0x34 : U"Keypad Enter";

--- a/Scan/Rapoo_E9070/setup.cmake
+++ b/Scan/Rapoo_E9070/setup.cmake
@@ -1,0 +1,38 @@
+###| CMake Kiibohd Controller Scan Module |###
+#
+# Written by Jacob Alexander in 2014 for the Kiibohd Controller
+#
+# Released into the Public Domain
+#
+###
+
+
+###
+# Path to this module
+#
+set ( MatrixARM_Path ${CMAKE_CURRENT_LIST_DIR} )
+
+
+###
+# Required Submodules
+#
+
+AddModule ( Scan MatrixARM )
+
+
+###
+# Module C files
+#
+
+set ( Module_SRCS
+	scan_loop.c
+)
+
+
+###
+# Compiler Family Compatibility
+#
+set ( ModuleCompatibility
+	arm
+)
+


### PR DESCRIPTION
This introduces Rapoo E9070 keyboard support (Teensy 3.2 + E9070's matrix) for both ANSI (US) and ISO (RU) layouts that I own.
If this is accepted, will add wiki page about teardown, wiring, tips and tricks of the process of converting of the shelf Rapoo E9070 into programmable one.

Depends on https://github.com/kiibohd/kll/pull/16