### PR TITLE
Disable virtual serial port by default

### DIFF
--- a/Output/pjrcUSB/capabilities.kll
+++ b/Output/pjrcUSB/capabilities.kll
@@ -92,7 +92,7 @@ enableKeyboard = 1;
 
 # CDC / Serial Port Endpoint
 enableVirtualSerialPort => enableVirtualSerialPort_define;
-enableVirtualSerialPort = 1;
+enableVirtualSerialPort = 0;
 
 # Raw I/O Endpoint
 # *Currently Unused*


### PR DESCRIPTION
It seems dangerous to leave this on. On Windows, at least, an unprivileged process can write to the serial port, and the debug interface could allow it to send privileged input or act as a keylogger.