### PR TITLE
Better support for non-Linux systems

### DIFF
--- a/Bootloader/CMakeLists.txt
+++ b/Bootloader/CMakeLists.txt
@@ -179,7 +179,7 @@ find_package ( Ctags ) # Optional
 
 if ( CTAGS_EXECUTABLE )
 	# Generate the ctags
-	execute_process( COMMAND ctags ${SRCS}
+	execute_process( COMMAND ${CTAGS_EXECUTABLE} ${SRCS}
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 	)
 endif ()

--- a/Lib/CMake/FindCtags.cmake
+++ b/Lib/CMake/FindCtags.cmake
@@ -9,7 +9,7 @@
 #   endif()
 
 find_program( CTAGS_EXECUTABLE
-	NAMES ctags
+	NAMES exctags ctags-exuberant ctags
 	DOC "ctags executable"
 )
 mark_as_advanced( CTAGS_EXECUTABLE )

--- a/Lib/CMake/FindDFUSuffix.cmake
+++ b/Lib/CMake/FindDFUSuffix.cmake
@@ -1,11 +1,11 @@
 # The module defines the following variables:
-#   DFU_SUFFIX_EXECUTABLE - path to ctags command line client
+#   DFU_SUFFIX_EXECUTABLE - path to dfu-suffix command line client
 #   DFU_SUFFIX_FOUND - true if the command line client was found
 #   DFU_SUFFIX_VERSION_STRING - the version of dfu-suffix found (since CMake 2.8.8)
 # Example usage:
 #   find_package( DFUSuffix )
 #   if( DFU_SUFFIX_FOUND )
-#     message("ctags found: ${DFU_SUFFIX_EXECUTABLE}")
+#     message("dfu-suffix found: ${DFU_SUFFIX_EXECUTABLE}")
 #   endif()
 
 find_program ( DFU_SUFFIX_EXECUTABLE

--- a/Lib/CMake/buildinfo.cmake
+++ b/Lib/CMake/buildinfo.cmake
@@ -151,7 +151,7 @@ if ( "${DETECTED_BUILD_KERNEL}" MATCHES "Darwin" )
 elseif ( "${DETECTED_BUILD_KERNEL}" MATCHES "CYGWIN" )
 	set( Build_OS ${CMAKE_SYSTEM} )
 
-else () # Linux
+elseif ( "${DETECTED_BUILD_KERNEL}" MATCHES "Linux" )
 	find_program( LSB_RELEASE lsb_release )
 	execute_process( COMMAND ${LSB_RELEASE} -dcs
 		OUTPUT_VARIABLE Build_OS
@@ -162,6 +162,8 @@ else () # Linux
 	# Replace quotes to be compatible with C
 	string( REPLACE "\"" "'" Build_OS ${Build_OS} )
 	string( REPLACE "\n" " " Build_OS ${Build_OS} )
+else () # Unknown
+	set( Build_OS ${CMAKE_SYSTEM} )
 endif ()
 message( "${Build_OS}" )
 

--- a/Lib/CMake/modules.cmake
+++ b/Lib/CMake/modules.cmake
@@ -215,7 +215,7 @@ if ( CTAGS_EXECUTABLE )
 	endforeach ()
 
 	# Generate the ctags
-	execute_process ( COMMAND ctags --fields=+l ${CTAG_PATHS}
+	execute_process ( COMMAND ${CTAGS_EXECUTABLE} --fields=+l ${CTAG_PATHS}
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 	)
 endif ()


### PR DESCRIPTION
Improve somewhat the support for building on non-Linux systems, such as FreeBSD. To do that, don't assume that ctags is exuberant ctags, and don't assume that any system that isn't macOS or Cygwin is Linux.