### PR TITLE
Add screensaver-like abilities (block animations on activity; shutdown LEDs on inactivity)

### DIFF
--- a/Macro/PartialMap/macro.h
+++ b/Macro/PartialMap/macro.h
@@ -39,6 +39,8 @@ void Macro_rotationState( uint8_t index, int8_t increment );
 uint8_t Macro_tick_update( TickStore *store, uint8_t type );
 
 void Macro_periodic();
+void Screensaver_periodic();
+
 void Macro_poll();
 void Macro_setup();
 

--- a/Macro/PixelMap/capabilities.kll
+++ b/Macro/PixelMap/capabilities.kll
@@ -26,7 +26,15 @@ pixel => Pixel_Pixel_capability();
 gamma => Pixel_GammaControl_capability( func : 1 );
 LEDGamma = 2.2;
 gamma_enabled => Pixel_gamma_default_define;
-gamma_enabled = "0"; # 0 - Disabled, 1 - Enabled
+gamma_enabled = "1"; # 0 - Disabled, 1 - Enabled
+
+# Keyboard screensaver settings: block animations on a given key press for some ms/shut down LEDs after some s of inactivity
+animation_screensaver_update => Pixel_AnimationScreenSaverUpdate();
+screensaver_led_shutdown => Pixel_screensaver_default_led_shutdown;
+screensaver_led_shutdown = "0"; # number of seconds before the leds are shutdown; if 0, screensaver is disabled
+screensaver_block_animation => Pixel_screensaver_default_block_animation;
+screensaver_block_animation = "0"; #number of MILLIseconds to block animation when key is pressed; if 0, animation is not blocked, if screensaver disabled this is ignored
+U[4-101,103-164,176-221,224-231,240-289] :+ animation_screensaver_update(); #key codes counting as an 'action' to stop screensaver to go to sleep (here all keys)
 
 # Animation Control
 # 0 - Pause/Resume

--- a/Macro/PixelMap/pixel.c
+++ b/Macro/PixelMap/pixel.c
@@ -2544,6 +2544,11 @@ pixel_process_final:
 	Latency_end_time( pixelLatencyResource );
 }
 
+//Screensaver periodic activity check to block animations/disable LEDs
+void Screensaver_periodic()
+{
+    //TODO
+}
 
 inline void Pixel_setup()
 {

--- a/Macro/PixelMap/pixel.h
+++ b/Macro/PixelMap/pixel.h
@@ -277,3 +277,5 @@ void Pixel_setup();
 
 void Pixel_setAnimationControl( AnimationControl control );
 
+void LED_SetPixels( uint8_t shouldSetOn );
+

--- a/Scan/Devices/ISSILed/led_scan.c
+++ b/Scan/Devices/ISSILed/led_scan.c
@@ -1113,6 +1113,14 @@ void LED_control( LedControl control, uint8_t arg )
 #endif
 }
 
+void LED_SetPixels( uint8_t shouldSetOn )
+{
+	if ( shouldSetOn )
+		LED_control( LedControl_on, 0 );
+	else
+		LED_control( LedControl_off, 0 );
+}
+
 void LED_control_capability( TriggerMacro *trigger, uint8_t state, uint8_t stateType, uint8_t *args )
 {
 	CapabilityState cstate = KLL_CapabilityState( state, stateType );


### PR DESCRIPTION
Playing with a new Kira and tried to add a basic screensaver-like capability to the firmware to get familiar with the code base. 

I'm sleeping not that far from my keyboard, so I wanted to stop the LED lightning if I stop typing for too long. 

Plus the Kira always animates to 'wave' by default and I felt it was weird to have animations while I'm typing. So the PR allows us to pause animation when the typist press some key, and resume it some x ms later.


To do that kind of stuff, I tried a bit to look first at the KLL spec, but the 'Timing' section doesn't seem to do the trick. Then I looked a bit at interrupts in the code base but it seemed too messy (architecture dependent?), so I just ended by using the Periodic_* functions on a larger timescale (see 2nd commit).

  
By default, the screensaver option is disabled (see comments in Macro/PixelMap/capabilities.kll to enable it, 3rd commit).