### PR TITLE
docs: fix simple typo, seqence -> sequence

### DIFF
--- a/Macro/PartialMap/trigger.c
+++ b/Macro/PartialMap/trigger.c
@@ -156,7 +156,7 @@ void Trigger_showTriggerMacroVote( TriggerMacroVote vote, uint8_t long_trigger_m
 
 // -- General --
 
-// Determine if long ResultMacro (more than 1 seqence element)
+// Determine if long ResultMacro (more than 1 sequence element)
 uint8_t Trigger_isLongResultMacro( const ResultMacro *macro )
 {
 	// Check the second sequence combo length


### PR DESCRIPTION
There is a small typo in Macro/PartialMap/trigger.c.

Should read `sequence` rather than `seqence`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md